### PR TITLE
Implementing the feature for paid vs free game. 

### DIFF
--- a/app/check-in/page.tsx
+++ b/app/check-in/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { getUserProfile, updateUserProfile } from '@/lib/ddb/users';
 import { createGameParticipant } from '@/lib/ddb/game-participants';
 import { useAuth } from '@/context/AuthContext';
+import { getGameById } from '@/lib/ddb/games';
 
 // Define skill level options with corresponding rating values
 const SKILL_LEVELS = [
@@ -130,7 +131,11 @@ function CheckInContent() {
         
         // Calculate the payment due amount
         const currentPaymentDue = userProfile?.PaymentDue || 0;
-        const additionalPayment = guestList.length * 15; // $15 per guest
+        // Fetch the game from DDB
+        const game = await getGameById(gameId);
+        const guestFee = game?.isPaid ? (game?.guestFee ?? 0) : 0;
+        const additionalPayment = guestList.length * guestFee;
+
         const newPaymentDue = currentPaymentDue + additionalPayment;
         
         // Update the user profile with the new PaymentDue amount

--- a/app/games/[id]/page.tsx
+++ b/app/games/[id]/page.tsx
@@ -364,17 +364,28 @@ export default function GamePage({ params }: GamePageProps) {
         
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-8 mb-8">
           <h1 className="text-3xl font-bold mb-2 dark:text-white">EW pick-up game</h1>
-          <p className="text-xl text-gray-700 dark:text-gray-300 mb-6">
+          <p className="text-xl text-gray-700 dark:text-gray-300 mb-4">
             {game?.date ? new Date(game.date + "T00:00:00-08:00").toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' }) : ''} at {(() => {
-              // Convert from 24-hour to 12-hour time format with AM/PM
               if (!game?.time) return '';
               const [hours, minutes] = game.time.split(':');
               const hour = parseInt(hours, 10);
               const amPm = hour >= 12 ? 'PM' : 'AM';
-              const hour12 = hour % 12 || 12; // Convert 0 to 12 for 12 AM
+              const hour12 = hour % 12 || 12;
               return `${hour12}:${minutes} ${amPm}`;
             })()}
           </p>
+
+          {/* Banner for Paid or Free Game */}
+          {game.isPaid ? (
+            <div className="bg-yellow-100 text-yellow-800 px-4 py-3 rounded mb-6 font-medium">
+              💰 This is a paid game. Guest fee: ${game.guestFee ?? 15}
+            </div>
+          ) : (
+            <div className="bg-green-100 text-green-800 px-4 py-3 rounded mb-6 font-medium">
+              This is a free game. No fee required.
+            </div>
+          )}
+
           
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
             <div>

--- a/app/games/create/page.tsx
+++ b/app/games/create/page.tsx
@@ -10,11 +10,13 @@ export default function CreateGamePage() {
   const { user } = useAuth();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
   const [formData, setFormData] = useState({
     date: "",
     startTime: "",
     location: "",
     isPaid: false,
+    guestFee: ""
   });
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -23,7 +25,10 @@ export default function CreateGamePage() {
     setError(null);
 
     try {
-      await createGame(formData);
+      await createGame({
+        ...formData,
+        guestFee: formData.isPaid ? 15 : 0,
+      });
       router.push("/games");
     } catch (err) {
       setError("Failed to create game. Please try again.");
@@ -56,9 +61,11 @@ export default function CreateGamePage() {
     <div className="container mx-auto py-12 px-4">
       <div className="max-w-4xl mx-auto">
         <h1 className="text-4xl font-bold mb-8 text-center">Create New Game</h1>
-        
+
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-8">
           <form onSubmit={handleSubmit} className="space-y-6">
+
+            {/* Date */}
             <div>
               <label htmlFor="date" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Game Date
@@ -74,6 +81,7 @@ export default function CreateGamePage() {
               />
             </div>
 
+            {/* Start Time */}
             <div>
               <label htmlFor="startTime" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Start Time
@@ -89,6 +97,7 @@ export default function CreateGamePage() {
               />
             </div>
 
+            {/* Location */}
             <div>
               <label htmlFor="location" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Game Location
@@ -100,11 +109,12 @@ export default function CreateGamePage() {
                 value={formData.location}
                 onChange={handleChange}
                 required
-                className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-black focus:border-transparent dark:bg-gray-700 dark:border-gray-600 dark:text-white"
                 placeholder="Enter game location"
+                className="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-black focus:border-transparent dark:bg-gray-700 dark:border-gray-600 dark:text-white"
               />
             </div>
 
+            {/* Paid Toggle */}
             <div className="flex items-center">
               <input
                 type="checkbox"
@@ -119,12 +129,14 @@ export default function CreateGamePage() {
               </label>
             </div>
 
+            {/* Error */}
             {error && (
               <div className="text-red-500 text-sm mt-2">
                 {error}
               </div>
             )}
 
+            {/* Submit */}
             <div className="flex justify-center">
               <button
                 type="submit"

--- a/data/types.ts
+++ b/data/types.ts
@@ -28,6 +28,7 @@ export interface Game {
   winner?: string;
   loser?: string;
   isPaid?: boolean;
+  guestFee?: number;
 }
 
 // Cognito/Amplify Auth types

--- a/lib/ddb/games.ts
+++ b/lib/ddb/games.ts
@@ -18,9 +18,10 @@ interface CreateGameParams {
   startTime: string;
   location: string;
   isPaid: boolean;
+  guestFee?: number;
 }
 
-export async function createGame({ date, startTime, location, isPaid }: CreateGameParams) {
+export async function createGame({ date, startTime, location, isPaid, guestFee }: CreateGameParams) {
   try {
     const command = new PutCommand({
       TableName: "Games",
@@ -31,6 +32,7 @@ export async function createGame({ date, startTime, location, isPaid }: CreateGa
         Location: location,
         Status: "UPCOMING",
         IsPaid: isPaid,
+        GuestFee: isPaid ? guestFee ?? 0 : 0, // ✅ store guest fee only if paid
       },
     });
 
@@ -41,6 +43,7 @@ export async function createGame({ date, startTime, location, isPaid }: CreateGa
     throw error;
   }
 }
+
 
 export async function getNextGame() {
   try {
@@ -105,7 +108,8 @@ export async function getGameById(id: string) {
       time: response.Item.StartTime,
       location: response.Item.Location,
       status: response.Item.Status,
-      isPaid: response.Item.IsPaid
+      isPaid: response.Item.IsPaid,
+      guestFee: response.Item.GuestFee ?? 0,
     };
   } catch (error) {
     console.error("Error getting game by ID:", error);


### PR DESCRIPTION
## Change Summary
This PR introduces support for distinguishing between paid and free pickup games. It also enables handling of guest fee logic, allowing guests to be charged only if the game is marked as paid. This was most awaited feature and I was able to implement this today. 


## Key Features

- **Game Creation UI**
  - Added a checkbox to mark the game as "Paid".
  - Default guest fee is `$15` for paid games.
  - `isPaid` and `guestFee` are now included in the `createGame` form and stored in the DB.

- **Game Display UI (`games/[id]/page.tsx`)**
  - Displays a **banner** indicating whether the game is **Paid** or **Free**.
  - Shows guest fee amount if it's a paid game.

- **Guest Fee Enforcement**
  - When adding guests, guest fee is only applied **if the game is marked as paid**.
  - Fixed bug where guest fee was always being applied, even for free games.


## Bug Fixes

- Guest fees incorrectly charged for free games.
- Ensured consistent fee logic across game creation, display, and guest management.
