### PR TITLE
Finance Admin Role Implementation

### DIFF
--- a/app/members/page.tsx
+++ b/app/members/page.tsx
@@ -6,7 +6,7 @@ import { UserProfile } from "@/data/types";
 import { useAuth } from "@/context/AuthContext";
 
 export default function MembersPage() {
-  const { isAdmin } = useAuth();
+  const { isAdmin, isFinanceAdmin } = useAuth();
   const [members, setMembers] = useState<UserProfile[]>([]);
   const [sortField, setSortField] = useState<"name" | "paymentDue">("name");
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
@@ -129,7 +129,7 @@ export default function MembersPage() {
   };
 
   const renderPaymentAmount = (userId: string, amount: number = 0) => {
-    if (editingPayment === userId && isAdmin) {
+    if (editingPayment === userId && isFinanceAdmin) {
       return (
         <div className="flex items-center space-x-2">
           <input
@@ -163,7 +163,7 @@ export default function MembersPage() {
     return (
       <div className="flex items-center space-x-2">
         <span>${amount.toFixed(2)}</span>
-        {isAdmin && (
+        {isFinanceAdmin && (
           <button
             onClick={() => {
               setEditingPayment(userId);

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -5,7 +5,7 @@ import { Amplify } from 'aws-amplify';
 import { signInWithRedirect, signOut, getCurrentUser } from 'aws-amplify/auth';
 import { AuthContextType, CognitoUser, UserProfile } from '@/data/types';
 import { getUserProfile } from '@/lib/ddb/users';
-import outputs from "../amplify_outputs.json"
+import outputs from "../amplify_outputs.json";
 
 Amplify.configure(outputs, { ssr: true });
 
@@ -19,6 +19,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<CognitoUser | null>(null);
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
   const [isMember, setIsMember] = useState<boolean>(false);
+  const [isFinanceAdmin, setIsFinanceAdmin] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
@@ -34,12 +35,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
         const userProfile = await getUserProfile(currentUser.userId);
         setIsAdmin(userProfile?.IsAdmin || false);
         setIsMember(userProfile?.IsMember || false);
+        setIsFinanceAdmin(userProfile?.IsFinanceAdmin || false);
+        setUser(currentUser as unknown as CognitoUser);
+      } else {
+        setUser(null);
       }
-      
-      // User object is already in the format we need
-      setUser(currentUser as unknown as CognitoUser);
     } catch (error) {
       // No current authenticated user
+      console.error("Auth check error:", error);
       setUser(null);
     } finally {
       setLoading(false);
@@ -66,13 +69,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }
 
   return (
-    <AuthContext.Provider value={{ 
+    <AuthContext.Provider value={{
       user,
       isAdmin,
       isMember,
-      loading, 
-      signIn: handleSignIn, 
-      signOut: handleSignOut 
+      isFinanceAdmin,
+      loading,
+      signIn: handleSignIn,
+      signOut: handleSignOut
     }}>
       {children}
     </AuthContext.Provider>

--- a/data/types.ts
+++ b/data/types.ts
@@ -14,6 +14,7 @@ export interface UserProfile {
   UpdatedAt?: string;
   IsMember?: boolean;
   IsAdmin?: boolean;
+  IsFinanceAdmin?: boolean;
   PaymentDue?: number;
 }
 
@@ -53,6 +54,7 @@ export interface AuthContextType {
   loading: boolean;
   isAdmin: boolean;
   isMember: boolean;
+  isFinanceAdmin: boolean;
   signIn: () => Promise<void>;
   signOut: () => Promise<void>;
 }


### PR DESCRIPTION
## 🔧 Finance Admin Role Implementation

### Features Added
- Introduced `IsFinanceAdmin` attribute to the Users table in DynamoDB.
- Updated `AuthContext` to include `isFinanceAdmin` flag.
- Restricted the ability to edit `PaymentDue` in the Members tab to finance admins only.

### Role Enforcement
- Only users with `IsFinanceAdmin: true` can edit payment balances.
- Regular admins and members cannot modify payment-related fields.

### Notes
- Existing users default to `IsFinanceAdmin: false`.
- Finance admin flag is manually set in the database for now.

